### PR TITLE
Reserve anticipated buffer space when we don't have enough to read the full frame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "websocket-codec"
 description = "A Tokio codec for the websocket protocol"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Tim Robinson <tim.g.robinson@gmail.com>"]
 repository = "https://github.com/1tgr/rust-websocket-codec"
 license = "MIT"


### PR DESCRIPTION
Tokio allocates an 8kb buffer in advance, but a message longer than that will cause Tokio to extend that buffer one byte at a time. We can improve on this by reserving as much space as we can on each call to `decode`.

Closes #1.